### PR TITLE
Make the page wider on large screens

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -1,3 +1,54 @@
 body {
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
+
+/* Make the content area wider for large screens (huge thanks @agoose77) */
+@media (min-width:1536px) {
+  [class*=article-grid] {
+    /* Widen the interior region by adding new equi-width columns */
+    grid-template-columns:
+      [screen-start]
+      .5rem
+      [screen-inset-start]
+      1fr
+      [page-start]
+      3rem
+      [page-inset-start]
+      minmax(4rem, 9rem)
+      [body-outset-start]
+      3rem
+
+      /* beginning of content window */
+      [body-start gutter-left-start]
+      1rem
+      [body-inset-start]
+      minmax(8ch, 10ch)
+
+      [middle-start]
+      minmax(8ch, 10ch)
+      [gutter-left-end]
+      minmax(8ch, 10ch) minmax(8ch, 10ch) minmax(8ch, 10ch) minmax(8ch, 10ch)
+      [gutter-right-start]
+      minmax(8ch, 10ch)
+      [middle-end]
+
+      minmax(8ch, 10ch)
+      [body-inset-end]
+      1rem
+      [body-end gutter-right-end]
+      /* end of content window */
+
+      3rem
+      [body-outset-end]
+      minmax(5rem, 13rem)
+      [page-inset-end]
+      3rem
+      [page-end]
+      1fr
+      [screen-inset-end]
+      .5rem
+      [screen-end]
+
+      !important
+  }
+}


### PR DESCRIPTION
The cards we're using for presenters and organizers on the AGU page are feeling cramped, so this PR makes the page wider when viewing on a large screen device.

Thanks to major help from @agoose77 on the [MyST communtiy discord](https://discord.mystmd.org/) :D

<!-- readthedocs-preview geojupyter-events start -->
---
:mag: Preview: https://geojupyter-events--6.org.readthedocs.build/en/6/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-events end -->