### PR TITLE
Fix RTD preview links

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: 'readthedocs/actions/preview@v1'
         with:
           project-slug: 'geojupyter-events'
+          single-version: true
           message-template: |
             ---
             :mag: Preview: {docs-pr-index-url}


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-events start -->
---
:mag: Preview: https://geojupyter-events--13.org.readthedocs.build/en/13/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-events end -->